### PR TITLE
[WP] Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 target/
 .settings/
 *.md
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+target/
+.settings/
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,14 @@ RUN mvn -Dmaven.test.skip=true install
 # unstaged build with just this PATH adjustment works!
 ENV PATH /app/ami3/target/appassembler/bin/:${PATH}
 
-#FROM openjdk:8
-#COPY --from=builder /app/ami3/target/appassembler/bin/ /bin/ami3/bin/
-#COPY --from=builder /app/ami3/target/*jar-with-dependencies.jar /bin/ami3/
-#ENV PATH /bin/ami3/bin:${PATH}
+# remove unused .bat files
+WORKDIR /app/ami3/target/appassembler/bin/
+RUN rm *.bat
+
+FROM openjdk:8
+# would like to copy more specifically the jar and binary files here, if possible, see #2
+COPY --from=builder /app/ami3/target/ /bin/ami3/
+ENV PATH /bin/ami3/appassembler/bin/:${PATH}
 
 VOLUME [ "/workspace" ]
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM maven:3-jdk-8 as builder
+
+# Alternative: clone remote code > not used because Dockerfile lifes in code repo
+# get and build ami3 (integrating https://github.com/petermr/cephis and https://github.com/petermr/normami)
+# WORKDIR /app
+# RUN git clone --depth 1 https://github.com/petermr/ami3.git && \
+
+WORKDIR /app/ami3
+COPY src src
+COPY pom.xml pom.xml
+
+RUN mvn -Dmaven.test.skip=true install
+
+# unstaged build with just this PATH adjustment works!
+ENV PATH /app/ami3/target/appassembler/bin/:${PATH}
+
+#FROM openjdk:8
+#COPY --from=builder /app/ami3/target/appassembler/bin/ /bin/ami3/bin/
+#COPY --from=builder /app/ami3/target/*jar-with-dependencies.jar /bin/ami3/
+#ENV PATH /bin/ami3/bin:${PATH}
+
+VOLUME [ "/workspace" ]
+WORKDIR /workspace
+
+CMD [ "/bin/bash" ]
+# docker build --tag ami3 .
+# docker run --rm -it norami-docker:0.0.1 ami-test a b c

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-
-
 # AMI
+
 (The command `norma` is being obsoleted and most commands will be of the form `ami-*`)
 
-Note. The commandline syntax is being migrated. See [AMI-STEM](./AMI-STEM.md)) and more recent docs [AMI-DOCS](./ami-docs/AMI.md)
+**Note.** The commandline syntax is being migrated. See [AMI-STEM](./AMI-STEM.md)) and more recent docs [AMI-DOCS](./ami-docs/AMI.md)
 
 A tool to convert a variety of inputs into normalized, tagged, XHTML (with embedded/linked SVG and PNG where
 appropriate). The initial emphasis is on scholarly publications but much of the technology is general.
@@ -22,30 +21,70 @@ For simply running `AMI` (not building) use the repository [ami-jars](http://git
 There are two approaches:
 
 ### running jars on commandline
+
 `ami-jars` provides an `uber-jar` ('jar-with-dependencies`) which can be run from the commandline:
+
 ```
 java -jar <jar> -cp <classpath> <mainClass>
 ```
+
 For this you need to know which main classes map onto the commands. 
 
 ### running `repo` and `bin` scripts
+
 The distrib has two directories:
+
  * `repo` which contains all the required jar files. 
  * `bin` which contains all the scripts. Set your classpath to include this directory.
 
-If you have the corect classpath, then exceuting `ami-pdf` on the commandline will run  the`ami-pdf` module. (Later we hope to make these submodules on the commandline.
-
+If you have the corect classpath, then exceuting `ami-pdf` on the commandline will run  the `ami-pdf` module. (Later we hope to make these submodules on the commandline.
 
 ## Building from source
 
-Norma can be built with maven3 and requires java 1.8 or greater. If you are building for the first time, or if your mods are minor you can skip the integration tests. The normal tests take a minute or two. To avoid all tests (which takes 20 secs or so) :
-```
+Norma can be built with maven3 and requires Java 1.8 or greater. If you are building for the first time, or if your mods are minor you can skip the integration tests. The normal tests take a minute or two. To avoid all tests (which takes 20 secs or so):
+
+```bash
 mvn install -Dmaven.test.skip=true
 ```
+
 will not run any tests.
 
+## Building Docker image
+
+You can also build a Docker image based:
+
+```bash
+docker build --tag ami3 .
+```
+
+Then you can run the container and execute commands in the container:
+
+```bash
+$ docker run --rm -it ami3
+root@aa87395224cc:/ami3# ami-pdf --help
+Usage: ami-pdf [OPTIONS]
+Description
+===========
+Convert PDFs to SVG-Text, SVG-graphics and Images. Does not process images,
+[...]
+```
+
+You can also directly run commands and exit the container rightaway and mount directories with data:
+
+```bash
+$ docker run --rm -it -v $(pwd):/workspace ami3 ami-image example.jpg
+Usage: ami-image [OPTIONS]
+Description
+===========
+        transforms image contents but only provides basic filtering (see ami-filter).
+Services include
+
+ identification of d
+ [...]
+```
 
 ## Contributing to development
+
 If you're interested in contributing please take a look at: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## *Everything after this is likely to be obsolete* 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Then you can run the container and execute commands in the container:
 
 ```bash
 $ docker run --rm -it ami3
-root@aa87395224cc:/ami3# ami-pdf --help
+root@aa87395224cc:/workspace# ami-pdf --help
 Usage: ami-pdf [OPTIONS]
 Description
 ===========


### PR DESCRIPTION
:rotating_light:  DO NOT MERGE, work in progress. :rotating_light: 

I've been trying to get ami3 to work in a Docker container, and it does.. BUT the Dockerfile in this PR shows how I'd like it to work in the commented out lines [here](https://github.com/petermr/ami3/pull/2/files#diff-3254677a7917c6c01f55212f86c57fbfR17): just copy over the binaries and the fat jar.

But the `ami-x` binary does not seem to find the jar:

```
$ docker run --rm -it ami3 ami-pdf --help
Error: Could not find or load main class org.contentmine.ami.tools.AMIPDFTool
```

Can you please help me with this question: _How do the binary files look for the `-with-dependcies.jar` ?_ (which I assume they have to)