### PR TITLE
Add additional tool dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,17 @@ FROM openjdk:8
 COPY --from=builder /app/ami3/target/ /bin/ami3/
 ENV PATH /bin/ami3/appassembler/bin/:${PATH}
 
-VOLUME [ "/workspace" ]
-WORKDIR /workspace
+# Add additional tools needed to handle PDF workflows and support Python tools:
+RUN apt-get update && \
+    apt-get -y install tesseract-ocr gocr default-jre python3 python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+## And install Tika and GROBID:
+RUN curl -k -o /opt/tika.jar https://www.mirrorservice.org/sites/ftp.apache.org/tika/tika-app-1.24.jar && \
+    curl -k -L -o /opt/grobid-src-0.5.3.zip https://github.com/kermitt2/grobid/archive/0.5.3.zip && \
+    curl -k -L -o /opt/grobid-core-0.5.3-onejar.jar https://github.com/kermitt2/grobid/releases/download/0.5.3/grobid-core-0.5.3-onejar.jar && \
+    cd /opt && unzip -o grobid-src-0.5.3.zip && mkdir -p /opt/grobid-0.5.3/grobid-core/build/libs/ && mv /opt/grobid-core-0.5.3-onejar.jar /opt/grobid-0.5.3/grobid-core/build/libs/ && \
+    mkdir -p /opt/grobid-0.5.3/grobid-home/tmp && chmod a+rwx /opt/grobid-0.5.3/grobid-home/tmp
 
 CMD [ "/bin/bash" ]
 # docker build --tag ami3 .


### PR DESCRIPTION
This commit add various dependencies to the Docker container, to support the various AMI tools. Specifically:

- Tesseract OCR
- GOCR
- GROBID 0.5.3

Note that this does make the image fairly large: 1.1GB compared to roughly 400MB without the additional dependencies.